### PR TITLE
feat: in-memory operations

### DIFF
--- a/branches/mod/betterdiscord/meta.js
+++ b/branches/mod/betterdiscord/meta.js
@@ -14,13 +14,17 @@ export async function setup(target, log) {
 		.then((r) => r.json())
 		.then((j) => j.assets.find((a) => a.browser_download_url?.includes(".asar")).browser_download_url);
 
-	const asarPath = join(target, "betterdiscord.asar");
+	if (typeof target === "string") {
+		const asarPath = join(target, "betterdiscord.asar");
 
-	const fileRes = await fetch(url);
+		const fileRes = await fetch(url);
 
-	// pipe into file
-	await rm(asarPath, { force: true });
-	await fileRes.body.pipeTo(Writable.toWeb(createWriteStream(asarPath)));
+		// pipe into file
+		await rm(asarPath, { force: true });
+		await fileRes.body.pipeTo(Writable.toWeb(createWriteStream(asarPath)));
+	} else {
+		await target.downloadTo("betterdiscord.asar", url);
+	}
 
 	log("Done!");
 }

--- a/branches/mod/equicord/meta.js
+++ b/branches/mod/equicord/meta.js
@@ -11,16 +11,23 @@ export const incompatibilities = ["betterdiscord", "vencord", "moonlight"];
 export async function setup(target, log) {
 	const releaseUrl = "https://github.com/Equicord/Equicord/releases/download/latest/";
 
-	mkdirSync(join(target, "equicord-desktop"), { recursive: true });
+	if (typeof target === "string") {
+		mkdirSync(join(target, "equicord-desktop"), { recursive: true });
 
-	for (const f of ["equibopMain.js", "equibopPreload.js", "renderer.js", "renderer.css"]) {
-		log(`Downloading ${f}...`);
+		for (const f of ["equibopMain.js", "equibopPreload.js", "renderer.js", "renderer.css"]) {
+			log(`Downloading ${f}...`);
 
-		const p = join(target, "equicord-desktop", f);
-		await rm(p, { force: true });
+			const p = join(target, "equicord-desktop", f);
+			await rm(p, { force: true });
 
-		const req = await fetch(releaseUrl + f);
-		await req.body.pipeTo(Writable.toWeb(createWriteStream(p)));
+			const req = await fetch(releaseUrl + f);
+			await req.body.pipeTo(Writable.toWeb(createWriteStream(p)));
+		}
+	} else {
+		for (const f of ["equibopMain.js", "equibopPreload.js", "renderer.js", "renderer.css"]) {
+			log(`Downloading ${f}...`);
+			await target.downloadTo(`equicord-desktop/${f}`, releaseUrl + f);
+		}
 	}
 
 	log("Done!");

--- a/branches/mod/moonlight/meta.js
+++ b/branches/mod/moonlight/meta.js
@@ -1,6 +1,7 @@
 import { mkdir, rm } from "fs/promises";
 import { join } from "path";
 import { Readable, Writable } from "stream";
+import { gunzipSync } from "zlib";
 import tar from "tar";
 
 export const name = "Moonlight";
@@ -32,7 +33,6 @@ export async function setup(target, log) {
 		const fileRes = await fetch(url);
 		const buf = Buffer.from(await fileRes.arrayBuffer());
 
-		const { gunzipSync } = await import("zlib");
 		const tarBuf = gunzipSync(buf);
 
 		const tarStream = (await import("tar-stream")).default;

--- a/branches/mod/moonlight/meta.js
+++ b/branches/mod/moonlight/meta.js
@@ -1,6 +1,6 @@
 import { mkdir, rm } from "fs/promises";
 import { join } from "path";
-import { Writable } from "stream";
+import { Readable, Writable } from "stream";
 import tar from "tar";
 
 export const name = "Moonlight";
@@ -14,19 +14,52 @@ export async function setup(target, log) {
 		.then((r) => r.json())
 		.then((j) => j.assets.find((a) => a.name === "dist.tar.gz").browser_download_url);
 
-	const moonlightPath = join(target, "moonlight");
-	const fileRes = await fetch(url);
+	if (typeof target === "string") {
+		const moonlightPath = join(target, "moonlight");
+		const fileRes = await fetch(url);
 
-	await rm(moonlightPath, { recursive: true, force: true });
-	await mkdir(moonlightPath);
+		await rm(moonlightPath, { recursive: true, force: true });
+		await mkdir(moonlightPath);
 
-	await fileRes.body.pipeTo(
-		Writable.toWeb(
-			tar.x({
-				cwd: moonlightPath,
-			}),
-		),
-	);
+		await fileRes.body.pipeTo(
+			Writable.toWeb(
+				tar.x({
+					cwd: moonlightPath,
+				}),
+			),
+		);
+	} else {
+		const fileRes = await fetch(url);
+		const buf = Buffer.from(await fileRes.arrayBuffer());
+
+		const { gunzipSync } = await import("zlib");
+		const tarBuf = gunzipSync(buf);
+
+		const tarStream = (await import("tar-stream")).default;
+		const extract = tarStream.extract();
+
+		const done = new Promise((resolve, reject) => {
+			extract.on("entry", (header, stream, next) => {
+				if (header.type !== "file") {
+					stream.resume();
+					next();
+					return;
+				}
+				const chunks = [];
+				stream.on("data", (chunk) => chunks.push(chunk));
+				stream.on("end", () => {
+					target.writeFile(`moonlight/${header.name}`, Buffer.concat(chunks));
+					next();
+				});
+				stream.on("error", reject);
+			});
+			extract.on("finish", resolve);
+			extract.on("error", reject);
+		});
+
+		Readable.from(tarBuf).pipe(extract);
+		await done;
+	}
 
 	log("Done!");
 }

--- a/branches/mod/vencord/meta.js
+++ b/branches/mod/vencord/meta.js
@@ -10,22 +10,43 @@ export const incompatibilities = ["betterdiscord", "equicord", "moonlight"];
 export async function setup(target, log) {
 	const releaseUrl = "https://github.com/Vendicated/Vencord/releases/download/devbuild/";
 
-	mkdirSync(join(target, "vencord-desktop"), { recursive: true });
+	if (typeof target === "string") {
+		mkdirSync(join(target, "vencord-desktop"), { recursive: true });
 
-	for (const f of ["vencordDesktopMain.js", "vencordDesktopPreload.js", "renderer.js", "vencordDesktopRenderer.css"]) {
-		log(`Downloading ${f}...`);
+		for (const f of [
+			"vencordDesktopMain.js",
+			"vencordDesktopPreload.js",
+			"renderer.js",
+			"vencordDesktopRenderer.css",
+		]) {
+			log(`Downloading ${f}...`);
 
-		const p = join(target, "vencord-desktop", f);
-		await rm(p, { force: true });
+			const p = join(target, "vencord-desktop", f);
+			await rm(p, { force: true });
 
-		const req = await fetch(releaseUrl + f);
-		await req.body.pipeTo(Writable.toWeb(createWriteStream(p)));
+			const req = await fetch(releaseUrl + f);
+			await req.body.pipeTo(Writable.toWeb(createWriteStream(p)));
+		}
+
+		const preloadSource = join(target, "vencord-desktop", "vencordDesktopPreload.js");
+		const preloadAlias = join(target, "vencord-desktop", "preload.js");
+		await rm(preloadAlias, { force: true });
+		await copyFile(preloadSource, preloadAlias);
+	} else {
+		for (const f of [
+			"vencordDesktopMain.js",
+			"vencordDesktopPreload.js",
+			"renderer.js",
+			"vencordDesktopRenderer.css",
+		]) {
+			log(`Downloading ${f}...`);
+			await target.downloadTo(`vencord-desktop/${f}`, releaseUrl + f);
+		}
+
+		const res = await fetch(releaseUrl + "vencordDesktopPreload.js");
+		const buf = Buffer.from(await res.arrayBuffer());
+		target.writeFile("vencord-desktop/preload.js", buf);
 	}
-
-	const preloadSource = join(target, "vencord-desktop", "vencordDesktopPreload.js");
-	const preloadAlias = join(target, "vencord-desktop", "preload.js");
-	await rm(preloadAlias, { force: true });
-	await copyFile(preloadSource, preloadAlias);
 
 	log("Done!");
 }

--- a/branches/mod/vencord/meta.js
+++ b/branches/mod/vencord/meta.js
@@ -43,9 +43,7 @@ export async function setup(target, log) {
 			await target.downloadTo(`vencord-desktop/${f}`, releaseUrl + f);
 		}
 
-		const res = await fetch(releaseUrl + "vencordDesktopPreload.js");
-		const buf = Buffer.from(await res.arrayBuffer());
-		target.writeFile("vencord-desktop/preload.js", buf);
+		await target.downloadTo("vencord-desktop/preload.js", releaseUrl + "vencordDesktopPreload.js");
 	}
 
 	log("Done!");

--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,7 @@
 	"port": 8080,
 	"host": "https://inject.shelter.uwu.network",
 	"stats": true,
+	"inMemory": false,
 	"setupIntervalHours": 3,
 	"tracing": {
 		"service": "sheltupdate",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,11 @@
 		"@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.203.0",
 		"@opentelemetry/sdk-node": "^0.203.0",
-		"archiver": "^5.0.2",
-		"glob": "^7.1.6",
+		"@zip.js/zip.js": "^2.8.23",
 		"hono": "^4.6.12",
 		"tar": "^6.0.5",
 		"tar-stream": "^3.1.8",
-		"unzipper": "^0.10.11"
+		"tinyglobby": "^0.2.15"
 	},
 	"devDependencies": {
 		"dprint": "^0.47.6"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"glob": "^7.1.6",
 		"hono": "^4.6.12",
 		"tar": "^6.0.5",
+		"tar-stream": "^3.1.8",
 		"unzipper": "^0.10.11"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,12 +35,9 @@ importers:
       '@opentelemetry/sdk-node':
         specifier: ^0.203.0
         version: 0.203.0(@opentelemetry/api@1.9.0)
-      archiver:
-        specifier: ^5.0.2
-        version: 5.3.2
-      glob:
-        specifier: ^7.1.6
-        version: 7.2.3
+      '@zip.js/zip.js':
+        specifier: ^2.8.23
+        version: 2.8.23
       hono:
         specifier: ^4.6.12
         version: 4.7.5
@@ -50,9 +47,9 @@ importers:
       tar-stream:
         specifier: ^3.1.8
         version: 3.1.8
-      unzipper:
-        specifier: ^0.10.11
-        version: 0.10.14
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.15
     devDependencies:
       dprint:
         specifier: ^0.47.6
@@ -1131,6 +1128,11 @@ packages:
       undici-types: 7.10.0
     dev: false
 
+  /@zip.js/zip.js@2.8.23:
+    resolution: {integrity: sha512-RB+RLnxPJFPrGvQ9rgO+4JOcsob6lD32OcF0QE0yg24oeW9q8KnTTNlugcDaIveEcCbclobJcZP+fLQ++sH0bw==}
+    engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=18.0.0'}
+    dev: false
+
   /acorn-import-attributes@1.9.5(acorn@8.14.0):
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -1159,55 +1161,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: false
-
-  /archiver-utils@2.1.0:
-    resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
-    engines: {node: '>= 6'}
-    dependencies:
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      lazystream: 1.0.1
-      lodash.defaults: 4.2.0
-      lodash.difference: 4.5.0
-      lodash.flatten: 4.4.0
-      lodash.isplainobject: 4.0.6
-      lodash.union: 4.6.0
-      normalize-path: 3.0.0
-      readable-stream: 2.3.8
-    dev: false
-
-  /archiver-utils@3.0.4:
-    resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
-    engines: {node: '>= 10'}
-    dependencies:
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      lazystream: 1.0.1
-      lodash.defaults: 4.2.0
-      lodash.difference: 4.5.0
-      lodash.flatten: 4.4.0
-      lodash.isplainobject: 4.0.6
-      lodash.union: 4.6.0
-      normalize-path: 3.0.0
-      readable-stream: 3.6.2
-    dev: false
-
-  /archiver@5.3.2:
-    resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
-    engines: {node: '>= 10'}
-    dependencies:
-      archiver-utils: 2.1.0
-      async: 3.2.6
-      buffer-crc32: 0.2.13
-      readable-stream: 3.6.2
-      readdir-glob: 1.1.3
-      tar-stream: 2.2.0
-      zip-stream: 4.1.1
-    dev: false
-
-  /async@3.2.6:
-    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
     dev: false
 
   /b4a@1.8.0:
@@ -1289,76 +1242,15 @@ packages:
       bare-path: 3.0.0
     dev: false
 
-  /base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-    dev: false
-
-  /big-integer@1.6.52:
-    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
-    engines: {node: '>=0.6'}
-    dev: false
-
-  /binary@0.3.0:
-    resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
-    dependencies:
-      buffers: 0.1.1
-      chainsaw: 0.1.0
-    dev: false
-
-  /bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-    dev: false
-
   /blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
     dev: true
-
-  /bluebird@3.4.7:
-    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
-    dev: false
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    dev: false
-
-  /brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-    dependencies:
-      balanced-match: 1.0.2
-    dev: false
-
-  /buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-    dev: false
-
-  /buffer-indexof-polyfill@1.0.2:
-    resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
-    engines: {node: '>=0.10'}
-    dev: false
-
-  /buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    dev: false
-
-  /buffers@0.1.1:
-    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
-    engines: {node: '>=0.2.0'}
-    dev: false
-
-  /chainsaw@0.1.0:
-    resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
-    dependencies:
-      traverse: 0.3.9
     dev: false
 
   /chownr@2.0.0:
@@ -1408,16 +1300,6 @@ packages:
     engines: {node: '>= 6'}
     dev: false
 
-  /compress-commons@4.1.2:
-    resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
-    engines: {node: '>= 10'}
-    dependencies:
-      buffer-crc32: 0.2.13
-      crc32-stream: 4.0.3
-      normalize-path: 3.0.0
-      readable-stream: 3.6.2
-    dev: false
-
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
@@ -1426,24 +1308,6 @@ packages:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
     dev: true
-
-  /core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-    dev: false
-
-  /crc-32@1.2.2:
-    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
-    engines: {node: '>=0.8'}
-    hasBin: true
-    dev: false
-
-  /crc32-stream@4.0.3:
-    resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
-    engines: {node: '>= 10'}
-    dependencies:
-      crc-32: 1.2.2
-      readable-stream: 3.6.2
-    dev: false
 
   /debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -1482,20 +1346,8 @@ packages:
       '@dprint/win32-x64': 0.47.6
     dev: true
 
-  /duplexer2@0.1.4:
-    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
-    dependencies:
-      readable-stream: 2.3.8
-    dev: false
-
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: false
-
-  /end-of-stream@1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
-    dependencies:
-      once: 1.4.0
     dev: false
 
   /error-stack-parser-es@1.0.5:
@@ -1561,8 +1413,16 @@ packages:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
     dev: false
 
-  /fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+  /fdir@6.5.0(picomatch@4.0.4):
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.4
     dev: false
 
   /fs-minipass@2.1.0:
@@ -1583,17 +1443,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /fstream@1.0.12:
-    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
-    engines: {node: '>=0.6'}
-    deprecated: This package is no longer supported.
-    dependencies:
-      graceful-fs: 4.2.11
-      inherits: 2.0.4
-      mkdirp: 0.5.6
-      rimraf: 2.7.1
-    dev: false
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1620,10 +1469,6 @@ packages:
       path-is-absolute: 1.0.1
     dev: false
 
-  /graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-    dev: false
-
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -1634,10 +1479,6 @@ packages:
   /hono@4.7.5:
     resolution: {integrity: sha512-fDOK5W2C1vZACsgLONigdZTRZxuBqFtcKh7bUQ5cVSbwI2RWjloJDcgFOVzbQrlI6pCmhlTsVYZ7zpLj4m4qMQ==}
     engines: {node: '>=16.9.0'}
-    dev: false
-
-  /ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: false
 
   /import-in-the-middle@1.14.2:
@@ -1677,48 +1518,13 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /isarray@1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-    dev: false
-
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
     dev: true
 
-  /lazystream@1.0.1:
-    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
-    engines: {node: '>= 0.6.3'}
-    dependencies:
-      readable-stream: 2.3.8
-    dev: false
-
-  /listenercount@1.0.1:
-    resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
-    dev: false
-
   /lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-    dev: false
-
-  /lodash.defaults@4.2.0:
-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
-    dev: false
-
-  /lodash.difference@4.5.0:
-    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
-    dev: false
-
-  /lodash.flatten@4.4.0:
-    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
-    dev: false
-
-  /lodash.isplainobject@4.0.6:
-    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
-    dev: false
-
-  /lodash.union@4.6.0:
-    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
     dev: false
 
   /long@5.3.2:
@@ -1759,17 +1565,6 @@ packages:
       brace-expansion: 1.1.11
     dev: false
 
-  /minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
-    engines: {node: '>=10'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: false
-
-  /minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: false
-
   /minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
@@ -1790,13 +1585,6 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
-    dependencies:
-      minimist: 1.2.8
-    dev: false
-
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -1809,11 +1597,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: false
-
-  /normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /ohash@2.0.11:
@@ -1843,8 +1626,9 @@ packages:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
     dev: true
 
-  /process-nextick-args@2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+  /picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
     dev: false
 
   /protobufjs@7.5.4:
@@ -1864,33 +1648,6 @@ packages:
       '@protobufjs/utf8': 1.1.0
       '@types/node': 24.3.0
       long: 5.3.2
-    dev: false
-
-  /readable-stream@2.3.8:
-    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
-    dev: false
-
-  /readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-    dev: false
-
-  /readdir-glob@1.1.3:
-    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
-    dependencies:
-      minimatch: 5.1.6
     dev: false
 
   /require-directory@2.1.1:
@@ -1919,31 +1676,11 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: false
 
-  /rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-    dependencies:
-      glob: 7.2.3
-    dev: false
-
-  /safe-buffer@5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-    dev: false
-
-  /safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: false
-
   /semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
     dev: true
-
-  /setimmediate@1.0.5:
-    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
-    dev: false
 
   /sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -2006,18 +1743,6 @@ packages:
       strip-ansi: 6.0.1
     dev: false
 
-  /string_decoder@1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
-    dependencies:
-      safe-buffer: 5.1.2
-    dev: false
-
-  /string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2033,17 +1758,6 @@ packages:
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: false
-
-  /tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.4
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
     dev: false
 
   /tar-stream@3.1.8:
@@ -2089,8 +1803,12 @@ packages:
       - react-native-b4a
     dev: false
 
-  /traverse@0.3.9:
-    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
+  /tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
     dev: false
 
   /tslib@2.8.1:
@@ -2127,25 +1845,6 @@ packages:
       pathe: 2.0.3
       ufo: 1.6.1
     dev: true
-
-  /unzipper@0.10.14:
-    resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
-    dependencies:
-      big-integer: 1.6.52
-      binary: 0.3.0
-      bluebird: 3.4.7
-      buffer-indexof-polyfill: 1.0.2
-      duplexer2: 0.1.4
-      fstream: 1.0.12
-      graceful-fs: 4.2.11
-      listenercount: 1.0.1
-      readable-stream: 2.3.8
-      setimmediate: 1.0.5
-    dev: false
-
-  /util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: false
 
   /workerd@1.20250730.0:
     resolution: {integrity: sha512-w6e0WM2YGfYQGmg0dewZeLUYIxAzMYK1R31vaS4HHHjgT32Xqj0eVQH+leegzY51RZPNCvw5pe8DFmW4MGf8Fg==}
@@ -2254,15 +1953,6 @@ packages:
       cookie: 1.0.2
       youch-core: 0.3.3
     dev: true
-
-  /zip-stream@4.1.1:
-    resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
-    engines: {node: '>= 10'}
-    dependencies:
-      archiver-utils: 3.0.4
-      compress-commons: 4.1.2
-      readable-stream: 3.6.2
-    dev: false
 
   /zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       tar:
         specifier: ^6.0.5
         version: 6.2.1
+      tar-stream:
+        specifier: ^3.1.8
+        version: 3.1.8
       unzipper:
         specifier: ^0.10.11
         version: 0.10.14
@@ -1207,8 +1210,83 @@ packages:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
     dev: false
 
+  /b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+    dev: false
+
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: false
+
+  /bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+    dev: false
+
+  /bare-fs@4.5.6:
+    resolution: {integrity: sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.12.0(bare-events@2.8.2)
+      bare-url: 2.4.0
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    dev: false
+
+  /bare-os@3.8.6:
+    resolution: {integrity: sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==}
+    engines: {bare: '>=1.14.0'}
+    dev: false
+
+  /bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+    dependencies:
+      bare-os: 3.8.6
+    dev: false
+
+  /bare-stream@2.12.0(bare-events@2.8.2):
+    resolution: {integrity: sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+    dependencies:
+      bare-events: 2.8.2
+      streamx: 2.25.0
+      teex: 1.0.1
+    transitivePeerDependencies:
+      - react-native-b4a
+    dev: false
+
+  /bare-url@2.4.0:
+    resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
+    dependencies:
+      bare-path: 3.0.0
     dev: false
 
   /base64-js@1.5.1:
@@ -1462,6 +1540,14 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+    dev: false
+
   /exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
@@ -1470,6 +1556,10 @@ packages:
   /exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
     dev: true
+
+  /fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+    dev: false
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1896,6 +1986,17 @@ packages:
     engines: {node: '>=4', npm: '>=6'}
     dev: true
 
+  /streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    dev: false
+
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -1945,9 +2046,23 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
+  /tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.5.6
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+    dev: false
+
   /tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0
@@ -1955,6 +2070,23 @@ packages:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+    dev: false
+
+  /teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    dev: false
+
+  /text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
     dev: false
 
   /traverse@0.3.9:

--- a/src/apiV1/moduleDownload/index.js
+++ b/src/apiV1/moduleDownload/index.js
@@ -7,12 +7,12 @@ import patch from "./patchModule.js";
 import { getBranch } from "../../common/branchesLoader.js";
 import { reportEndpoint, reportV1Cached, reportV1Patched } from "../../dashboard/reporting.js";
 import { populateReqAttrs, withSection } from "../../common/tracer.js";
-import { cacheBase } from "../../common/fsCache.js";
+import { cacheBase, inMemory, v1ModuleCache } from "../../common/fsCache.js";
 import { getEtag } from "../../common/proxy/index.js";
 
 const cacheEtags = new Map();
 
-export const handleModuleDownload = withSection("v1 download module", async (span, c) => {
+const handleFs = withSection("v1 download module", async (span, c) => {
 	const { branch, /*channel,*/ module, version } = c.req.param();
 
 	const branchFull = getBranch(branch);
@@ -57,3 +57,48 @@ export const handleModuleDownload = withSection("v1 download module", async (spa
 
 	return basicRedirect(c);
 });
+
+const handleInMemory = withSection("v1 download module", async (span, c) => {
+	const { branch, /*channel,*/ module, version } = c.req.param();
+
+	const branchFull = getBranch(branch);
+	if (!branchFull) {
+		return c.notFound("Invalid sheltupdate branch");
+	}
+
+	reportEndpoint("v1_module_download");
+
+	populateReqAttrs(span, c);
+
+	if (module === "discord_desktop_core") {
+		const cacheName = `${module}-${branch}-${version}`;
+
+		const etag = await getEtag(c.req.url, {}, [version, version.substring(branchFull.version.toString().length)]);
+
+		const cached = v1ModuleCache.get(cacheName);
+		if (cached) {
+			if (etag && etag === cached.etag) {
+				span.addEvent("Served cached discord_desktop_core");
+				reportV1Cached();
+
+				c.header("Content-Type", "application/zip");
+				return c.body(cached.buffer);
+			} else {
+				span.addEvent(`etag mismatch, expecting ${cached.etag} but got ${etag}`);
+				v1ModuleCache.delete(cacheName);
+			}
+		}
+
+		reportV1Patched();
+		const buffer = await patch(c);
+
+		v1ModuleCache.set(cacheName, { etag, buffer });
+
+		c.header("Content-Type", "application/zip");
+		return c.body(buffer);
+	}
+
+	return basicRedirect(c);
+});
+
+export const handleModuleDownload = inMemory ? handleInMemory : handleFs;

--- a/src/apiV1/moduleDownload/index.js
+++ b/src/apiV1/moduleDownload/index.js
@@ -12,7 +12,7 @@ import { getEtag } from "../../common/proxy/index.js";
 
 const cacheEtags = new Map();
 
-const handleFs = withSection("v1 download module", async (span, c) => {
+export const handleModuleDownload = withSection("v1 download module", async (span, c) => {
 	const { branch, /*channel,*/ module, version } = c.req.param();
 
 	const branchFull = getBranch(branch);
@@ -26,79 +26,54 @@ const handleFs = withSection("v1 download module", async (span, c) => {
 
 	if (module === "discord_desktop_core") {
 		const cacheName = `${module}-${branch}-${version}`;
-		const cacheDir = path.join(cacheBase, `v1-desktop-core`, cacheName);
-		const cacheFinalFile = path.join(cacheDir, "module.zip");
-
 		const etag = await getEtag(c.req.url, {}, [version, version.substring(branchFull.version.toString().length)]);
 
-		if (existsSync(cacheFinalFile)) {
-			// if cache is valid
-			if (etag && etag === cacheEtags.get(cacheFinalFile)) {
-				span.addEvent("Served cached discord_desktop_core");
-				reportV1Cached();
+		if (inMemory) {
+			const cached = v1ModuleCache.get(cacheName);
+			if (cached) {
+				if (etag && etag === cached.etag) {
+					span.addEvent("Served cached discord_desktop_core");
+					reportV1Cached();
 
-				c.header("Content-Type", "application/zip");
-				return c.body(readFileSync(cacheFinalFile));
-			} else {
-				span.addEvent(`etag mismatch, expecting ${cacheEtags.get(cacheFinalFile)} but got ${etag}`);
-
-				cacheEtags.delete(cacheFinalFile);
-				// delete cache and fall through to patch
-				rmSync(cacheDir, { recursive: true, force: true });
+					c.header("Content-Type", "application/zip");
+					return c.body(cached.buffer);
+				} else {
+					span.addEvent(`etag mismatch, expecting ${cached.etag} but got ${etag}`);
+					v1ModuleCache.delete(cacheName);
+				}
 			}
+
+			reportV1Patched();
+			const buffer = await patch(c);
+
+			v1ModuleCache.set(cacheName, { etag, buffer });
+
+			c.header("Content-Type", "application/zip");
+			return c.body(buffer);
+		} else {
+			const cacheDir = path.join(cacheBase, `v1-desktop-core`, cacheName);
+			const cacheFinalFile = path.join(cacheDir, "module.zip");
+
+			if (existsSync(cacheFinalFile)) {
+				if (etag && etag === cacheEtags.get(cacheFinalFile)) {
+					span.addEvent("Served cached discord_desktop_core");
+					reportV1Cached();
+
+					c.header("Content-Type", "application/zip");
+					return c.body(readFileSync(cacheFinalFile));
+				} else {
+					span.addEvent(`etag mismatch, expecting ${cacheEtags.get(cacheFinalFile)} but got ${etag}`);
+					cacheEtags.delete(cacheFinalFile);
+					rmSync(cacheDir, { recursive: true, force: true });
+				}
+			}
+
+			cacheEtags.set(cacheFinalFile, etag);
+
+			reportV1Patched();
+			return patch(c, cacheDir, cacheFinalFile);
 		}
-
-		// set expected etag
-		cacheEtags.set(cacheFinalFile, etag);
-
-		reportV1Patched();
-		return patch(c, cacheDir, cacheFinalFile);
 	}
 
 	return basicRedirect(c);
 });
-
-const handleInMemory = withSection("v1 download module", async (span, c) => {
-	const { branch, /*channel,*/ module, version } = c.req.param();
-
-	const branchFull = getBranch(branch);
-	if (!branchFull) {
-		return c.notFound("Invalid sheltupdate branch");
-	}
-
-	reportEndpoint("v1_module_download");
-
-	populateReqAttrs(span, c);
-
-	if (module === "discord_desktop_core") {
-		const cacheName = `${module}-${branch}-${version}`;
-
-		const etag = await getEtag(c.req.url, {}, [version, version.substring(branchFull.version.toString().length)]);
-
-		const cached = v1ModuleCache.get(cacheName);
-		if (cached) {
-			if (etag && etag === cached.etag) {
-				span.addEvent("Served cached discord_desktop_core");
-				reportV1Cached();
-
-				c.header("Content-Type", "application/zip");
-				return c.body(cached.buffer);
-			} else {
-				span.addEvent(`etag mismatch, expecting ${cached.etag} but got ${etag}`);
-				v1ModuleCache.delete(cacheName);
-			}
-		}
-
-		reportV1Patched();
-		const buffer = await patch(c);
-
-		v1ModuleCache.set(cacheName, { etag, buffer });
-
-		c.header("Content-Type", "application/zip");
-		return c.body(buffer);
-	}
-
-	return basicRedirect(c);
-});
-
-export const handleModuleDownload = inMemory ? handleInMemory : handleFs;

--- a/src/apiV1/moduleDownload/patchModule.js
+++ b/src/apiV1/moduleDownload/patchModule.js
@@ -10,8 +10,34 @@ import basicProxy from "../../common/proxy/index.js";
 import { ensureBranchIsReady, getBranch, getSingleBranchMetas } from "../../common/branchesLoader.js";
 import { section, withSection } from "../../common/tracer.js";
 import { dcMain, dcPreload } from "../../desktopCore/index.js";
+import { inMemory } from "../../common/fsCache.js";
+import { readZip, writeZip, overlayFiles, setText, streamToBuffer } from "../../common/virtualFiles.js";
 
-export default withSection("v1 module patcher", async (span, c, cacheDir, cacheFinalFile) => {
+const patchInMemory = withSection("v1 module patcher", async (span, c) => {
+	const { branch: branch_, /*channel,*/ version } = c.req.param();
+
+	await ensureBranchIsReady(branch_);
+
+	const branch = getBranch(branch_);
+
+	const zipBuffer = await section("download original module", async () => {
+		const prox = await basicProxy(c, {}, [version, version.substring(branch.version.toString().length)]);
+		return await streamToBuffer(stream.Readable.from(prox.body));
+	});
+
+	const files = await section("extract original module", () => readZip(zipBuffer));
+
+	section("patch files", () => {
+		overlayFiles(files, branch.extraFiles);
+		setText(files, "index.js", dcMain.replace("// __BRANCHES_MAIN__", branch.main));
+		setText(files, "preload.js", dcPreload.replace("// __BRANCHES_PRELOAD__", branch.preload));
+		setText(files, "branches.json", JSON.stringify(getSingleBranchMetas(), null, 4));
+	});
+
+	return await section("create module zip", () => writeZip(files));
+});
+
+const patchFs = withSection("v1 module patcher", async (span, c, cacheDir, cacheFinalFile) => {
 	const { branch: branch_, /*channel,*/ version } = c.req.param();
 	//const { platform, host_version } = c.req.query();
 
@@ -68,3 +94,5 @@ export default withSection("v1 module patcher", async (span, c, cacheDir, cacheF
 	c.header("Content-Type", "application/zip");
 	return c.body(readFileSync(cacheFinalFile));
 });
+
+export default inMemory ? patchInMemory : patchFs;

--- a/src/apiV1/moduleDownload/patchModule.js
+++ b/src/apiV1/moduleDownload/patchModule.js
@@ -1,10 +1,7 @@
-import { readFileSync, writeFileSync, cpSync, createWriteStream, rmSync } from "fs";
+import { mkdirSync, readFileSync, writeFileSync, cpSync, rmSync, readdirSync, statSync } from "fs";
 
 import stream from "stream";
-import { join } from "path";
-
-import unzipper from "unzipper";
-import archiver from "archiver";
+import { join, relative, posix, win32 } from "path";
 
 import basicProxy from "../../common/proxy/index.js";
 import { ensureBranchIsReady, getBranch, getSingleBranchMetas } from "../../common/branchesLoader.js";
@@ -37,6 +34,19 @@ const patchInMemory = withSection("v1 module patcher", async (span, c) => {
 	return await section("create module zip", () => writeZip(files));
 });
 
+const collectFiles = (dir) => {
+	const files = new Map();
+	const walk = (d) => {
+		for (const entry of readdirSync(d)) {
+			const full = join(d, entry);
+			if (statSync(full).isDirectory()) walk(full);
+			else files.set(relative(dir, full).replaceAll(win32.sep, posix.sep), readFileSync(full));
+		}
+	};
+	walk(dir);
+	return files;
+};
+
 const patchFs = withSection("v1 module patcher", async (span, c, cacheDir, cacheFinalFile) => {
 	const { branch: branch_, /*channel,*/ version } = c.req.param();
 	//const { platform, host_version } = c.req.query();
@@ -48,16 +58,17 @@ const patchFs = withSection("v1 module patcher", async (span, c, cacheDir, cache
 
 	const cacheExtractDir = join(cacheDir, "extract" + Math.random().toString(16));
 
-	const s = await section("download original module", async () => {
+	await section("download and extract original module", async () => {
 		const prox = await basicProxy(c, {}, [version, version.substring(branch.version.toString().length)]);
+		const zipBuffer = await streamToBuffer(stream.Readable.from(prox.body));
+		const files = await readZip(zipBuffer);
 
-		let s = stream.Readable.from(prox.body);
-
-		let t = s.pipe(unzipper.Extract({ path: cacheExtractDir }));
-
-		await new Promise((res) => t.on("close", res));
-
-		return s;
+		mkdirSync(cacheExtractDir, { recursive: true });
+		for (const [path, data] of files) {
+			const dest = join(cacheExtractDir, path);
+			mkdirSync(join(dest, ".."), { recursive: true });
+			writeFileSync(dest, data);
+		}
 	});
 
 	section("copy files", () => {
@@ -71,23 +82,9 @@ const patchFs = withSection("v1 module patcher", async (span, c, cacheDir, cache
 	});
 
 	await section("create module zip", async () => {
-		const outputStream = createWriteStream(`${cacheFinalFile}`);
-
-		const archive = archiver("zip");
-
-		archive.pipe(outputStream);
-
-		archive.directory(cacheExtractDir, false);
-
-		archive.finalize();
-
-		await new Promise((res) => outputStream.on("close", res));
-
-		s.destroy();
-
-		outputStream.close();
-		outputStream.destroy();
-
+		const files = collectFiles(cacheExtractDir);
+		const finalBuf = await writeZip(files);
+		writeFileSync(cacheFinalFile, finalBuf);
 		rmSync(cacheExtractDir, { recursive: true });
 	});
 

--- a/src/apiV2/patchModule.js
+++ b/src/apiV2/patchModule.js
@@ -5,7 +5,7 @@ import { mkdirSync, writeFileSync, readFileSync, cpSync, rmSync } from "fs";
 import { join, relative, win32, posix } from "path";
 
 import tar from "tar";
-import glob from "glob";
+import { globSync } from "tinyglobby";
 
 import { brotliDecompressSync, brotliCompressSync, constants } from "zlib";
 import { ensureBranchIsReady, getBranch, getSingleBranchMetas } from "../common/branchesLoader.js";
@@ -187,7 +187,7 @@ const patchFs = withSection("v2 module patcher", async (span, m, branchName) => 
 			cpSync(cacheDir, filesDir, { recursive: true });
 		}
 
-		const allFiles = glob.sync(`${filesDir}/**/*.*`);
+		const allFiles = globSync("**/*.*", { cwd: filesDir, absolute: true });
 		for (const f of allFiles) {
 			// The updater always expects '/' as separator in delta_manifest.json (regardless of platform)
 			const key = relative(filesDir, f).replaceAll(win32.sep, posix.sep);

--- a/src/apiV2/patchModule.js
+++ b/src/apiV2/patchModule.js
@@ -11,9 +11,10 @@ import { brotliDecompressSync, brotliCompressSync, constants } from "zlib";
 import { ensureBranchIsReady, getBranch, getSingleBranchMetas } from "../common/branchesLoader.js";
 import { section, withSection } from "../common/tracer.js";
 import { SpanStatusCode } from "@opentelemetry/api";
-import { cacheBase } from "../common/fsCache.js";
+import { cacheBase, inMemory } from "../common/fsCache.js";
 import { reportV2Cached, reportV2Patched } from "../dashboard/reporting.js";
 import { dcMain, dcPreload } from "../desktopCore/index.js";
+import { readTar, writeTar, overlayFiles, setText } from "../common/virtualFiles.js";
 
 const cache = {};
 
@@ -43,7 +44,86 @@ const brotlify = withSection("brotli", (span, buf) =>
 	brotliCompressSync(buf, { params: { [constants.BROTLI_PARAM_QUALITY]: 9 } }),
 );
 
-export const patch = withSection("v2 module patcher", async (span, m, branchName) => {
+const patchInMemory = withSection("v2 module patcher", async (span, m, branchName) => {
+	const cacheName = getCacheName("discord_desktop_core", m.module_version, branchName);
+
+	const cached = cache[cacheName];
+	if (cached) {
+		const expectedSource = cacheDigests.get(cached.hash);
+
+		if (expectedSource && expectedSource === m.package_sha256) {
+			reportV2Cached();
+			return cached.hash;
+		} else {
+			cacheDigests.delete(cached.hash);
+			delete cache[cacheName];
+		}
+	}
+	reportV2Patched();
+
+	await ensureBranchIsReady(branchName);
+
+	const branch = getBranch(branchName);
+
+	const tarBuffer = await section("download original module", async () => {
+		const data = await download(m.url);
+		return brotliDecompressSync(data);
+	});
+
+	const files = await section("extract original module", () => readTar(tarBuffer));
+
+	section("patch module files", () => {
+		let deltaManifest = JSON.parse(files.get("delta_manifest.json").toString("utf8"));
+
+		const moddedIndex = dcMain.replace("// __BRANCHES_MAIN__", branch.main);
+		setText(files, "files/index.js", moddedIndex);
+		deltaManifest.files["index.js"] = { New: { Sha256: sha256(moddedIndex) } };
+
+		const moddedPreload = dcPreload.replace("// __BRANCHES_PRELOAD__", branch.preload);
+		setText(files, "files/preload.js", moddedPreload);
+		deltaManifest.files["preload.js"] = { New: { Sha256: sha256(moddedPreload) } };
+
+		const availableBranches = JSON.stringify(getSingleBranchMetas(), null, 4);
+		setText(files, "files/branches.json", availableBranches);
+		deltaManifest.files["branches.json"] = { New: { Sha256: sha256(availableBranches) } };
+
+		for (const [relPath, data] of branch.extraFiles) {
+			const archivePath = posix.join("files", relPath);
+			files.set(archivePath, data);
+		}
+
+		for (const [path, data] of files) {
+			if (!path.startsWith("files/")) continue;
+			const key = path.slice("files/".length);
+			deltaManifest.files[key] = {
+				New: {
+					Sha256: sha256(data),
+				},
+			};
+		}
+
+		setText(files, "delta_manifest.json", JSON.stringify(deltaManifest));
+	});
+
+	return await section("compress final module", async () => {
+		const tarBuf = await writeTar(files);
+
+		const final = brotlify(tarBuf);
+
+		const finalHash = sha256(final);
+
+		cache[cacheName] = {
+			hash: finalHash,
+			final,
+		};
+
+		cacheDigests.set(finalHash, m.package_sha256);
+
+		return finalHash;
+	});
+});
+
+const patchFs = withSection("v2 module patcher", async (span, m, branchName) => {
 	const cacheName = getCacheName("discord_desktop_core", m.module_version, branchName);
 
 	const cached = cache[cacheName];
@@ -152,6 +232,8 @@ export const patch = withSection("v2 module patcher", async (span, m, branchName
 	});
 });
 
+export const patch = inMemory ? patchInMemory : patchFs;
+
 export const getFinal = withSection("v2 module patcher", (span, req) => {
 	const moduleName = req.param("moduleName");
 	const moduleVersion = req.param("moduleVersion");
@@ -169,5 +251,3 @@ export const getFinal = withSection("v2 module patcher", (span, req) => {
 
 	return cached.final;
 });
-
-// export const getChecksum = async (m, branch) => sha256(await patch(m, branch));

--- a/src/common/branchesLoader.js
+++ b/src/common/branchesLoader.js
@@ -3,7 +3,7 @@ import { join, basename, relative, win32, posix } from "path";
 import { pathToFileURL } from "url";
 import { createHash } from "crypto";
 
-import glob from "glob";
+import { globSync } from "tinyglobby";
 import { config, srcDir, version as shupVersion } from "./config.js";
 import { cacheBase, inMemory } from "./fsCache.js";
 import { dcVersion } from "../desktopCore/index.js";
@@ -66,7 +66,9 @@ const getBranchFilesCacheDir = (b) => join(cacheBase, `extra-files-${b}`);
 const init = withSection("branch finder", async (span) => {
 	const branchDir = join(srcDir, "..", "branches");
 
-	const dirs = glob.sync(join(branchDir, "*", "*"));
+	const dirs = globSync("*/*", { cwd: branchDir, onlyDirectories: true, absolute: true }).map((d) =>
+		d.replace(/\/+$/, ""),
+	);
 
 	span.addEvent("found branch list", { dirs });
 
@@ -77,7 +79,7 @@ const init = withSection("branch finder", async (span) => {
 			const name = splits.pop();
 			const type = splits.pop();
 
-			let files = glob.sync(`${d}/*`);
+			let files = globSync("*", { cwd: d, absolute: true, onlyFiles: false }).map((f) => f.replace(/\/+$/, ""));
 
 			let main = "";
 			let preload = "";
@@ -118,7 +120,7 @@ const init = withSection("branch finder", async (span) => {
 					const filename = basename(f);
 					if (internalFiles.has(filename)) continue;
 
-					const subFiles = glob.sync(`${f}/**/*.*`);
+					const subFiles = globSync("**/*.*", { cwd: f, absolute: true });
 					if (subFiles.length > 0) {
 						for (const sf of subFiles) {
 							const relPath = relative(d, sf).replaceAll(win32.sep, posix.sep);
@@ -130,7 +132,7 @@ const init = withSection("branch finder", async (span) => {
 					}
 				}
 
-				const allFiles = glob.sync(`${d}/**/*.*`);
+				const allFiles = globSync("**/*.*", { cwd: d, absolute: true });
 				const fileHashes = allFiles.map((f) => sha256(readFileSync(f)));
 
 				const version = parseInt(
@@ -163,7 +165,7 @@ const init = withSection("branch finder", async (span) => {
 					cpSync(oldPath, newPath, { recursive: true });
 				}
 
-				const allFiles = glob.sync(`${d}/**/*.*`);
+				const allFiles = globSync("**/*.*", { cwd: d, absolute: true });
 				const fileHashes = allFiles.map((f) => sha256(readFileSync(f)));
 
 				const version = parseInt(
@@ -348,7 +350,7 @@ const runBranchSetups = withSection("periodic branch setups", async (span) => {
 					throw e;
 				}
 
-				const allFiles = glob.sync(`${cacheDir}/**/*.*`);
+				const allFiles = globSync("**/*.*", { cwd: cacheDir, absolute: true });
 				branches[b].cacheDirs = [cacheDir];
 				branches[b].files = allFiles;
 

--- a/src/common/branchesLoader.js
+++ b/src/common/branchesLoader.js
@@ -1,13 +1,14 @@
 import { mkdirSync, readFileSync, cpSync } from "fs";
-import { join, basename } from "path";
+import { join, basename, relative, win32, posix } from "path";
 import { pathToFileURL } from "url";
 import { createHash } from "crypto";
 
 import glob from "glob";
 import { config, srcDir, version as shupVersion } from "./config.js";
-import { cacheBase } from "./fsCache.js";
+import { cacheBase, inMemory } from "./fsCache.js";
 import { dcVersion } from "../desktopCore/index.js";
 import { withSection, section } from "./tracer.js";
+import { overlayFiles } from "./virtualFiles.js";
 
 let branches = {};
 
@@ -108,44 +109,82 @@ const init = withSection("branch finder", async (span) => {
 				}
 			}
 
-			// copy extra files into cache
-			const cacheDir = getBranchFilesCacheDir(name);
-			mkdirSync(cacheDir);
+			const internalFiles = new Set(["main.js", "preload.js", "meta.js"]);
 
-			for (let i = 0; i < files.length; i++) {
-				const oldPath = files[i];
-				const newPath = join(cacheDir, oldPath.slice(d.length + 1));
-				files[i] = newPath;
+			if (inMemory) {
+				// read extra files into memory
+				const extraFiles = new Map();
+				for (const f of files) {
+					const filename = basename(f);
+					if (internalFiles.has(filename)) continue;
 
-				cpSync(oldPath, newPath, { recursive: true });
+					const subFiles = glob.sync(`${f}/**/*.*`);
+					if (subFiles.length > 0) {
+						for (const sf of subFiles) {
+							const relPath = relative(d, sf).replaceAll(win32.sep, posix.sep);
+							extraFiles.set(relPath, readFileSync(sf));
+						}
+					} else {
+						const relPath = relative(d, f).replaceAll(win32.sep, posix.sep);
+						extraFiles.set(relPath, readFileSync(f));
+					}
+				}
+
+				const allFiles = glob.sync(`${d}/**/*.*`);
+				const fileHashes = allFiles.map((f) => sha256(readFileSync(f)));
+
+				const version = parseInt(
+					sha256(fileHashes.join(" ") + main + preload + dcVersion + shupVersion).substring(0, 2),
+					16,
+				);
+
+				branches[name] = {
+					extraFiles,
+					main,
+					preload,
+					version,
+					type,
+					displayName,
+					description,
+					incompatibilities,
+					hidden,
+					setup,
+				};
+			} else {
+				// copy extra files into cache dir on disk
+				const cacheDir = getBranchFilesCacheDir(name);
+				mkdirSync(cacheDir);
+
+				for (let i = 0; i < files.length; i++) {
+					const oldPath = files[i];
+					const newPath = join(cacheDir, oldPath.slice(d.length + 1));
+					files[i] = newPath;
+
+					cpSync(oldPath, newPath, { recursive: true });
+				}
+
+				const allFiles = glob.sync(`${d}/**/*.*`);
+				const fileHashes = allFiles.map((f) => sha256(readFileSync(f)));
+
+				const version = parseInt(
+					sha256(fileHashes.join(" ") + main + preload + dcVersion + shupVersion).substring(0, 2),
+					16,
+				);
+
+				branches[name] = {
+					files: allFiles.filter((f) => !internalFiles.has(basename(f))),
+					cacheDirs: [cacheDir],
+					main,
+					preload,
+					version,
+					type,
+					displayName,
+					description,
+					incompatibilities,
+					hidden,
+					setup,
+				};
 			}
-
-			// we will reset these anyway later for branches with setups,
-			// but for the rest of them, just populate it now.
-			const allFiles = glob.sync(`${d}/**/*.*`);
-			const fileHashes = allFiles.map((f) => sha256(readFileSync(f)));
-
-			// the list of branches is sent along with the module and accounting for that is difficult so
-			// just factor the sheltupdate release number into the version and leave it at that.
-			const version = parseInt(
-				sha256(fileHashes.join(" ") + main + preload + dcVersion + shupVersion).substring(0, 2),
-				16,
-			);
-			const internalFiles = ["main.js", "preload.js", "meta.js"];
-
-			branches[name] = {
-				files: allFiles.filter((f) => !internalFiles.includes(basename(f))),
-				cacheDirs: [cacheDir],
-				main,
-				preload,
-				version,
-				type,
-				displayName,
-				description,
-				incompatibilities,
-				hidden,
-				setup,
-			};
 
 			// create wait-for-setup promises
 			if (setup) {
@@ -206,36 +245,53 @@ const init = withSection("branch finder", async (span) => {
 
 			const bs = bNames.map((n) => branches[n]);
 
-			branches[key] = {
-				// these will be updated by setups later so have to make it lazy
-				get files() {
-					return bs.map((x) => x.files).reduce((x, a) => a.concat(x), []);
-				},
-				get cacheDirs() {
-					return bs.flatMap((b) => b.cacheDirs);
-				},
-				main: bs
-					.map((x) => x.main)
-					.filter((p) => p)
-					.join("\n\t"),
-				preload: bs
-					.map((x) => x.preload)
-					.filter((p) => p)
-					.join("\n"),
-				// cap the version well under u32::max or some rust code somewhere in the client dies
-				// this will be updated by setups later so have to make it lazy
-				get version() {
-					return Number(BigInt(bs.map((x) => x.version).reduce((x, a) => `${x}0${a}`)) % BigInt(2 ** 28)) + 100;
-				},
-				type: "mixed",
-			};
+			if (inMemory) {
+				branches[key] = {
+					get extraFiles() {
+						const out = new Map();
+						for (const b of bs) overlayFiles(out, b.extraFiles);
+						return out;
+					},
+					main: bs
+						.map((x) => x.main)
+						.filter((p) => p)
+						.join("\n\t"),
+					preload: bs
+						.map((x) => x.preload)
+						.filter((p) => p)
+						.join("\n"),
+					get version() {
+						return Number(BigInt(bs.map((x) => x.version).reduce((x, a) => `${x}0${a}`)) % BigInt(2 ** 28)) + 100;
+					},
+					type: "mixed",
+				};
+			} else {
+				branches[key] = {
+					get files() {
+						return bs.map((x) => x.files).reduce((x, a) => a.concat(x), []);
+					},
+					get cacheDirs() {
+						return bs.flatMap((b) => b.cacheDirs);
+					},
+					main: bs
+						.map((x) => x.main)
+						.filter((p) => p)
+						.join("\n\t"),
+					preload: bs
+						.map((x) => x.preload)
+						.filter((p) => p)
+						.join("\n"),
+					get version() {
+						return Number(BigInt(bs.map((x) => x.version).reduce((x, a) => `${x}0${a}`)) % BigInt(2 ** 28)) + 100;
+					},
+					type: "mixed",
+				};
+			}
 		}
 	});
 });
 
 const runBranchSetups = withSection("periodic branch setups", async (span) => {
-	// perfect for async code I guess
-
 	await Promise.all(Object.keys(branches).map(singleSetup));
 
 	async function singleSetup(b) {
@@ -252,26 +308,56 @@ const runBranchSetups = withSection("periodic branch setups", async (span) => {
 			const newProm = new Promise((r) => (newResolve = r));
 			setupPromises.set(b, [newProm, newResolve, true]);
 
-			// create a folder in cache
-			const cacheDir = getBranchFilesCacheDir(b);
-			try {
-				await branches[b].setup(cacheDir, (...a) => span.addEvent(a.join(" ")));
-			} catch (e) {
-				// we failed! leave it in a "setting up" state until next time.
-				setupPromises.set(b, [newProm, newResolve, true, true]);
-				throw e;
+			if (inMemory) {
+				const setupFiles = new Map();
+
+				const setupTarget = {
+					writeFile(relPath, data) {
+						setupFiles.set(
+							relPath.replaceAll(win32.sep, posix.sep),
+							Buffer.isBuffer(data) ? data : Buffer.from(data),
+						);
+					},
+					async downloadTo(relPath, url) {
+						const res = await fetch(url);
+						const buf = Buffer.from(await res.arrayBuffer());
+						setupFiles.set(relPath.replaceAll(win32.sep, posix.sep), buf);
+					},
+				};
+
+				try {
+					await branches[b].setup(setupTarget, (...a) => span.addEvent(a.join(" ")));
+				} catch (e) {
+					setupPromises.set(b, [newProm, newResolve, true, true]);
+					throw e;
+				}
+
+				branches[b].extraFiles = setupFiles;
+
+				const fileHashes = [...setupFiles.values()].map((buf) => sha256(buf));
+				branches[b].version = parseInt(
+					sha256(fileHashes.join(" ") + branches[b].main + branches[b].preload + dcVersion).substring(0, 2),
+					16,
+				);
+			} else {
+				const cacheDir = getBranchFilesCacheDir(b);
+				try {
+					await branches[b].setup(cacheDir, (...a) => span.addEvent(a.join(" ")));
+				} catch (e) {
+					setupPromises.set(b, [newProm, newResolve, true, true]);
+					throw e;
+				}
+
+				const allFiles = glob.sync(`${cacheDir}/**/*.*`);
+				branches[b].cacheDirs = [cacheDir];
+				branches[b].files = allFiles;
+
+				const fileHashes = allFiles.map((f) => sha256(readFileSync(f)));
+				branches[b].version = parseInt(
+					sha256(fileHashes.join(" ") + branches[b].main + branches[b].preload + dcVersion).substring(0, 2),
+					16,
+				);
 			}
-
-			// regenerate files and version
-			const allFiles = glob.sync(`${cacheDir}/**/*.*`);
-			branches[b].cacheDirs = [cacheDir];
-			branches[b].files = allFiles;
-
-			const fileHashes = allFiles.map((f) => sha256(readFileSync(f)));
-			branches[b].version = parseInt(
-				sha256(fileHashes.join(" ") + branches[b].main + branches[b].preload + dcVersion).substring(0, 2),
-				16,
-			);
 
 			setupPromises.set(b, [newProm, newResolve, false]);
 

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -24,6 +24,7 @@ export const config = Object.freeze({
 	host: rawCfg?.host || `http://localhost:${rawCfg?.port || 8080}`,
 	stats: rawCfg?.stats ?? true,
 	setupIntervalHours: rawCfg?.setupIntervalHours ?? 3,
+	inMemory: rawCfg?.inMemory ?? false,
 	tracing: {
 		service: rawCfg?.tracing?.service ?? "sheltupdate",
 		log: rawCfg?.tracing?.log ?? true,

--- a/src/common/fsCache.js
+++ b/src/common/fsCache.js
@@ -1,7 +1,15 @@
 import { mkdtempSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { config } from "./config.js";
 
-export const cacheBase = mkdtempSync(join(tmpdir(), "sheltupdate-cache-"));
+export const inMemory = config.inMemory;
 
-console.log("file system cache at ", cacheBase);
+// FS mode: temp directory for disk-based caching
+export const cacheBase = inMemory ? undefined : mkdtempSync(join(tmpdir(), "sheltupdate-cache-"));
+
+// In-memory mode: Map for V1 module cache
+export const v1ModuleCache = inMemory ? new Map() : undefined;
+
+if (!inMemory) console.log("file system cache at ", cacheBase);
+else console.log("using in-memory cache");

--- a/src/common/virtualFiles.js
+++ b/src/common/virtualFiles.js
@@ -1,0 +1,109 @@
+import { Readable } from "stream";
+import archiver from "archiver";
+import unzipper from "unzipper";
+import tarStream from "tar-stream";
+
+// A virtual file tree is a Map<string, Buffer> where keys are posix-style relative paths.
+
+const normalizePath = (p) => p.replace(/\\/g, "/").replace(/^\.\//, "");
+
+export const streamToBuffer = async (stream) => {
+	const chunks = [];
+	return await new Promise((resolve, reject) => {
+		stream.on("data", (chunk) => chunks.push(chunk));
+		stream.on("error", reject);
+		stream.on("end", () => resolve(Buffer.concat(chunks)));
+	});
+};
+
+export const readZip = async (buffer) => {
+	const files = new Map();
+	const dir = await unzipper.Open.buffer(buffer);
+
+	for (const entry of dir.files) {
+		if (entry.type === "Directory") continue;
+		const path = normalizePath(entry.path);
+		files.set(path, await entry.buffer());
+	}
+
+	return files;
+};
+
+export const writeZip = async (files) => {
+	const archive = archiver("zip");
+	const chunks = [];
+
+	const done = new Promise((resolve, reject) => {
+		archive.on("data", (chunk) => chunks.push(chunk));
+		archive.on("end", () => resolve());
+		archive.on("error", reject);
+	});
+
+	for (const [path, data] of [...files.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+		archive.append(data, { name: path });
+	}
+
+	archive.finalize();
+	await done;
+
+	return Buffer.concat(chunks);
+};
+
+export const readTar = async (buffer) => {
+	const files = new Map();
+	const extract = tarStream.extract();
+
+	const done = new Promise((resolve, reject) => {
+		extract.on("entry", (header, stream, next) => {
+			if (header.type !== "file") {
+				stream.resume();
+				next();
+				return;
+			}
+			const chunks = [];
+			stream.on("data", (chunk) => chunks.push(chunk));
+			stream.on("end", () => {
+				files.set(normalizePath(header.name), Buffer.concat(chunks));
+				next();
+			});
+			stream.on("error", reject);
+		});
+		extract.on("finish", resolve);
+		extract.on("error", reject);
+	});
+
+	Readable.from(buffer).pipe(extract);
+	await done;
+
+	return files;
+};
+
+export const writeTar = async (files) => {
+	const pack = tarStream.pack();
+	const chunks = [];
+
+	const done = new Promise((resolve, reject) => {
+		pack.on("data", (chunk) => chunks.push(chunk));
+		pack.on("end", () => resolve());
+		pack.on("error", reject);
+	});
+
+	for (const [path, data] of [...files.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+		pack.entry({ name: path }, data);
+	}
+
+	pack.finalize();
+	await done;
+
+	return Buffer.concat(chunks);
+};
+
+export const overlayFiles = (base, extra) => {
+	for (const [path, data] of extra) {
+		base.set(path, data);
+	}
+};
+
+export const setText = (files, path, text) => {
+	files.set(normalizePath(path), Buffer.from(text));
+};

--- a/src/common/virtualFiles.js
+++ b/src/common/virtualFiles.js
@@ -1,6 +1,5 @@
 import { Readable } from "stream";
-import archiver from "archiver";
-import unzipper from "unzipper";
+import { ZipReader, ZipWriter, Uint8ArrayReader, Uint8ArrayWriter } from "@zip.js/zip.js";
 import tarStream from "tar-stream";
 
 // A virtual file tree is a Map<string, Buffer> where keys are posix-style relative paths.
@@ -18,35 +17,29 @@ export const streamToBuffer = async (stream) => {
 
 export const readZip = async (buffer) => {
 	const files = new Map();
-	const dir = await unzipper.Open.buffer(buffer);
+	const reader = new ZipReader(new Uint8ArrayReader(new Uint8Array(buffer)));
+	const entries = await reader.getEntries();
 
-	for (const entry of dir.files) {
-		if (entry.type === "Directory") continue;
-		const path = normalizePath(entry.path);
-		files.set(path, await entry.buffer());
+	for (const entry of entries) {
+		if (entry.directory) continue;
+		const path = normalizePath(entry.filename);
+		const data = await entry.getData(new Uint8ArrayWriter());
+		files.set(path, Buffer.from(data));
 	}
 
+	await reader.close();
 	return files;
 };
 
 export const writeZip = async (files) => {
-	const archive = archiver("zip");
-	const chunks = [];
-
-	const done = new Promise((resolve, reject) => {
-		archive.on("data", (chunk) => chunks.push(chunk));
-		archive.on("end", () => resolve());
-		archive.on("error", reject);
-	});
+	const writer = new ZipWriter(new Uint8ArrayWriter());
 
 	for (const [path, data] of [...files.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-		archive.append(data, { name: path });
+		await writer.add(path, new Uint8ArrayReader(new Uint8Array(data)));
 	}
 
-	archive.finalize();
-	await done;
-
-	return Buffer.concat(chunks);
+	const result = await writer.close();
+	return Buffer.from(result);
 };
 
 export const readTar = async (buffer) => {


### PR DESCRIPTION
Brings in-memory operations for extract/repacking of branches, this improves security and reduces fs overhead of extracting to a tmpfs. Also migrates to `@zip.js/zip.js` and `tinyglobby` for smaller install.
